### PR TITLE
Correct the cache key for phpcs

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: "actions/cache@v2.1.1"
         with:
           path: ".build/php_codesniffer"
-          key: "php-${{ matrix.php-version }}-php_codesniffer-${{ hashFiles('composer.lock') }}"
+          key: "php-${{ matrix.php-version }}-php_codesniffer-${{ github.sha }}"
           restore-keys: "php-${{ matrix.php-version }}-php_codesniffer-"
 
       - name: "Run squizlabs/php_codesniffer"


### PR DESCRIPTION
The cache key for php_codesniffer needs to be changing with the source code, so the cache is updated.

This is the same method used in the static analysis tools.